### PR TITLE
Closes EN-232: Updated progress message

### DIFF
--- a/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
+++ b/dfu/src/main/java/no/nordicsemi/android/dfu/DfuBaseService.java
@@ -1437,8 +1437,8 @@ public abstract class DfuBaseService extends IntentService implements DfuProgres
 				break;
 			default:
 					// progress is in percents
-					final String title = info.getTotalParts() == 1 ? getString(R.string.dfu_status_uploading) : getString(R.string.dfu_status_uploading_part, info.getCurrentPart(), info.getTotalParts());
-					final String text = getString(R.string.dfu_status_uploading_msg, deviceName);
+					final String title = "Uploading";
+					final String text = "Transmitting firmware to Device";
 					builder.setOngoing(true).setContentTitle(title).setContentText(text).setProgress(100, progress, false);
 		}
 


### PR DESCRIPTION
For some reason, we were having an issue loading the progress message from the DFU library. This moves the text into inline code (which normally we'd avoid but this does get around the issue)

Please see corresponding wolf/shire PR's for testing steps

https://github.com/ifit/wolf/pull/6447
https://github.com/ifit/shire/pull/3230
https://github.com/ifit/DfuAndroidLibrary/pull/5